### PR TITLE
We are not enqueing anymore UI events coming from the bind. This woul…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ buildscript {
 
 allprojects {
     group = "com.github.eliekarouz.feedbacktree"
-    version = System.getenv("GITHUB_REF_NAME")?.takeIf { it.isNotEmpty() } ?: "0.14.0"
+    version = System.getenv("GITHUB_REF_NAME")?.takeIf { it.isNotEmpty() } ?: "0.15.0"
 
     repositories {
         google()

--- a/feedbacktree/src/main/java/com/feedbacktree/flow/core/EnqueueRecursiveEmissionsObservable.kt
+++ b/feedbacktree/src/main/java/com/feedbacktree/flow/core/EnqueueRecursiveEmissionsObservable.kt
@@ -1,0 +1,97 @@
+/*
+ * Created by eliek on 2/19/2023
+ * Copyright (c) 2023 eliekarouz. All rights reserved.
+ */
+
+package com.feedbacktree.flow.core
+
+import io.reactivex.Observable
+import io.reactivex.ObservableSource
+import io.reactivex.Observer
+import io.reactivex.internal.fuseable.HasUpstreamObservableSource
+import io.reactivex.internal.observers.BasicFuseableObserver
+import io.reactivex.plugins.RxJavaPlugins
+
+/**
+ * Transforms recursive(re-entrant) emissions into sequential emissions.
+ *
+ * In case onNext did not complete yet, using this operator guarantees that the next emission does not
+ * start unless the previous emission is fully processed by the downstream observer.
+ * In other terms, in case of recursion, the stack trace will not grow but the `onNext` emissions will be done sequentially.
+ */
+internal fun <T> Observable<T>.enqueueRecursiveEmissions(): Observable<T> {
+    return RxJavaPlugins.onAssembly(EnqueueRecursiveEmissionsObservable(this))
+}
+
+private class EnqueueRecursiveEmissionsObservable<T>(
+    val source: ObservableSource<T>
+) : Observable<T>(), HasUpstreamObservableSource<T> {
+
+    override fun source(): ObservableSource<T> {
+        return source
+    }
+
+    override fun subscribeActual(observer: Observer<in T>) {
+        source.subscribe(EnqueueRecursiveEmissionsObserver(observer))
+    }
+
+    class EnqueueRecursiveEmissionsObserver<T : Any>(actual: Observer<in T>) :
+        BasicFuseableObserver<T, T>(actual) {
+
+        private val queueLock = SequentialExecutionQueue()
+
+        override fun onNext(t: T) {
+            if (sourceMode != NONE) {
+                downstream.onNext(null)
+                return
+            }
+            queueLock.enqueueOrExecuteAll {
+                if (done) {
+                    return@enqueueOrExecuteAll
+                }
+                downstream.onNext(t)
+            }
+        }
+
+        override fun poll(): T? {
+            return qd.poll()
+        }
+
+        override fun requestFusion(mode: Int): Int {
+            return transitiveBoundaryFusion(mode)
+        }
+    }
+}
+
+internal class SequentialExecutionQueue {
+
+    private val queue = mutableListOf<() -> Unit>()
+
+    fun enqueueOrExecuteAll(mutate: () -> Unit) {
+        var executeMutation = enqueue(mutate) ?: return
+        do {
+            executeMutation()
+            val nextExecuteMutation = dequeue() ?: return
+            executeMutation = nextExecuteMutation
+        } while (true)
+    }
+
+    private fun enqueue(mutate: () -> Unit): (() -> Unit)? {
+        synchronized(this) {
+            val wasEmpty = queue.isEmpty()
+            queue.add(mutate)
+            return if (wasEmpty) {
+                mutate
+            } else null
+        }
+    }
+
+    private fun dequeue(): (() -> Unit)? {
+        synchronized(this) {
+            if (queue.isNotEmpty()) {
+                queue.removeAt(0)
+            }
+            return queue.firstOrNull()
+        }
+    }
+}

--- a/feedbacktree/src/main/java/com/feedbacktree/flow/core/Feedbacks.kt
+++ b/feedbacktree/src/main/java/com/feedbacktree/flow/core/Feedbacks.kt
@@ -282,6 +282,8 @@ class BindingsBuilder<Event>(
 
 /**
  * Bi-directional binding of a system State to external state machine and events from it.
+ *
+ * Note that [bind] does not enqueue any event to the scheduler.
  */
 fun <State, Event> bind(bindings: BindingsBuilder<Event>.(Observable<State>) -> Unit): (ObservableSchedulerContext<State>) -> Observable<Event> =
     { observableSchedulerContext: ObservableSchedulerContext<State> ->
@@ -293,7 +295,6 @@ fun <State, Event> bind(bindings: BindingsBuilder<Event>.(Observable<State>) -> 
             Bindings(subscriptions = bindings.subscriptions, events = bindings.events)
         }, { bindings: Bindings<Event> ->
             Observable.merge(bindings.events).concatWith(Observable.never())
-                .enqueue(observableSchedulerContext.scheduler)
         }, { it.dispose() })
     }
 

--- a/feedbacktree/src/main/java/com/feedbacktree/flow/core/FlowNode.kt
+++ b/feedbacktree/src/main/java/com/feedbacktree/flow/core/FlowNode.kt
@@ -137,12 +137,12 @@ internal class FlowNode<InputT : Any, StateT : Any, EventT : Any, OutputT : Any,
     private val enterStatePublishSubject = PublishSubject.create<FlowEvent<StateT, EventT>>()
 
     private fun backdoorFeedback(): Feedback<FlowState<StateT, OutputT>, FlowEvent<StateT, EventT>> =
-        bindWithScheduler { osc ->
+        bind { source ->
             subscriptions = listOf(
-                osc.source.subscribe { flowState.onNext(it) },
+                source.subscribe { flowState.onNext(it) },
 
 
-                osc.source.skip(1).subscribe { state ->
+                source.skip(1).subscribe { state ->
                     // We will only trigger a rendering pass when the flow doesn't emit an output and ends.
                     // The output will be propagated synchronously to the parent flows. Once a parent/grandparent captures the output,
                     // its state will be updated and it's at that time that we will trigger the rendering pass.
@@ -154,7 +154,7 @@ internal class FlowNode<InputT : Any, StateT : Any, EventT : Any, OutputT : Any,
                 // This means the if we collect the flow output directly from the system, the output will be delayed.
                 // We are using this feedback loop to do that because we don't have an observerOn(scheduler) and the state is emitted instantly
                 // as soon as it goes out of the stepper.
-                osc.source.mapNotNull { it.flowOutput }.subscribe { flowOutput ->
+                source.mapNotNull { it.flowOutput }.subscribe { flowOutput ->
                     outputPublishSubject.onNext(flowOutput)
                 }
             )


### PR DESCRIPTION
We are not any more enqueing  UI events coming from the bind. This would improve the interoperability with compose

To avoid recursive rendering, we used enqueueRecursiveEmissions guarantees that rendering is done in sequence, this can happen if you emit an event why you are rendering the screen.